### PR TITLE
Fix regexp? already refers to cljs.core/regexp?

### DIFF
--- a/src/route_map/core.cljc
+++ b/src/route_map/core.cljc
@@ -29,10 +29,10 @@
                  [])
          first)))
 
-(defn regexp?
-  [x]
-  #?(:cljs (cljs.core/regexp? x)
-     :clj (instance? java.util.regex.Pattern x)))
+#?(:clj
+   (defn regexp?
+     [x]
+     (instance? java.util.regex.Pattern x)))
 
 (defn -match [acc node [x & rpth :as pth] params parents wgt]
   (if (empty? pth)


### PR DESCRIPTION
Fixes annoying warning output of shadow-cljs:

```
------ WARNING #1 - :redef -----------------------------------------------------
 Resource: route_map/core.cljc:32:1
 regexp? already refers to: cljs.core/regexp? being replaced by: route-map.core/regexp?
--------------------------------------------------------------------------------
```