### PR TITLE
fix warning

### DIFF
--- a/src/route_map/core.cljc
+++ b/src/route_map/core.cljc
@@ -1,5 +1,6 @@
 (ns route-map.core
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str])
+  (:refer-clojure :exclude [regexp?]))
 
 (defn pathify [path]
   (filterv #(not (str/blank? %)) (str/split path #"/")))


### PR DESCRIPTION
regexp? already refers to: cljs.core/regexp? being replaced by: route-map.core/regexp?